### PR TITLE
Move isLoaded state update to fetchTasks finally block

### DIFF
--- a/client/src/pages/Statistic.jsx
+++ b/client/src/pages/Statistic.jsx
@@ -44,7 +44,6 @@ export default function Statistic({ setNavDisplay, navDisplay }) {
     setPendAmount(allTasks.length - doneTasks.length);
     setTaskAmount(allTasks.length);
     setDoneAmout(doneTasks.length);
-    setIsLoaded(true);
   };
 
   async function fetchTasks() {
@@ -53,6 +52,8 @@ export default function Statistic({ setNavDisplay, navDisplay }) {
       setTasks(() => taskList);
     } catch (error) {
       console.log(error);
+    } finally {
+      setIsLoaded(true);
     }
   }
 


### PR DESCRIPTION
The setIsLoaded(true) call was moved from the calculateStats function to the finally block of fetchTasks to ensure loading state is updated regardless of success or error during task fetching.